### PR TITLE
Add a simple endpoint for serving ad content.

### DIFF
--- a/src/controllers/ad.js
+++ b/src/controllers/ad.js
@@ -1,0 +1,11 @@
+var debug = require('debug')('ad');
+
+module.exports.get = function () {
+  return function * (next) {
+    if (this.method !== 'GET') {
+      return yield next;
+    }
+    debug('serving ad', this.query);
+    this.body = 'Hello this is ad for: ' + JSON.stringify(this.query);
+  };
+};

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ var route = require('koa-route');
 var logger = require('koa-logger');
 var app = koa();
 var debug = require('debug')('index');
+var ad = require('./controllers/ad');
 var auth = require('./controllers/auth');
 var intents = require('./controllers/intents');
 var adManifest = require('./controllers/ad-manifest');
@@ -25,6 +26,7 @@ app.use(route.get('/', function * () {
   this.body = 'Welcome to the Vault.';
 }));
 app.use(route.get('/ad-manifest', adManifest.get(runtime)));
+app.use(route.get('/ad', ad.get(runtime)));
 app.use(route.post('/auth', auth.push(runtime)));
 app.use(route.post('/intents', intents.push(runtime)));
 app.use(route.get('/sync/:userId', sync.get(runtime)));


### PR DESCRIPTION
This could be used in the future to redirect to real ads, or serve pass-through ads from partners.

Related: https://github.com/brave/browser/pull/215
