### PR TITLE
Use an async wreck call.

### DIFF
--- a/src/brave-hapi.js
+++ b/src/brave-hapi.js
@@ -5,6 +5,7 @@
 */
 
 var underscore = require('underscore')
+var wreck = require('wreck')
 
 var exports = {}
 
@@ -81,5 +82,24 @@ var ErrorInspect = function (err) {
 }
 
 exports.error = { inspect: ErrorInspect }
+
+/**
+ * Async wrapper for wreck.post to return the response payload.
+ */
+var WreckPost = async function (server, opts) {
+  return new Promise((resolve, reject) => {
+    wreck.post(
+      server,
+      opts,
+      (err, response, body) => {
+        if (err) {
+          return reject(err)
+        }
+        resolve(body)
+      })
+  })
+}
+
+exports.wreck = { post: WreckPost }
 
 module.exports = exports


### PR DESCRIPTION
This helps flatten the indentation quite a bit as well as follows the pattern that we use in the other files. I couldn't find a way to leverage await with the wreck package out-of-the box, but I'll open an issue on their side.

Easier code diff: https://github.com/brave/vault/pull/19/files?w=1
