### PR TITLE
[issue 42] ensure that x is a string for `new Buffer(x)`

### DIFF
--- a/src/controllers/helper.js
+++ b/src/controllers/helper.js
@@ -37,8 +37,8 @@ exports.verify = async function (debug, user, data) {
     return boom.badRequest('header.signature is invalid: ' + JSON.stringify(header.signature))
   }
 
-  if (typeof header.publicKey !== 'string') {
-    return boom.badRequest('header.publicKey is invalid: ' + JSON.stringify(header.publicKey))
+  if (typeof user.publicKey !== 'string') {
+    return boom.badRequest('user.publicKey is invalid: ' + JSON.stringify(user.publicKey))
   }
 
   combo = JSON.stringify({ userId: user.userId, nonce: header.nonce, payload: payload })


### PR DESCRIPTION
fix https://github.com/brave/vault/issues/42
